### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "drift-common"]
 	path = drift-common
-	url = https://github.com/drift-labs/drift-common.git
+	url = https://github.com/velocity-exchange/drift-common.git


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` -> `github.com/velocity-exchange/` (`.gitmodules` submodule URL, `.github/workflows` comment)
- `@drift-labs/` npm scope -> `@velocity-exchange/` (package.json deps, import statements in source files, bun.lock, yarn.lock)

Total: 9 files changed, 32 substitutions.

## Files modified

| File | What changed |
|------|-------------|
| `.gitmodules` | `drift-common` submodule URL updated to `velocity-exchange` org |
| `.github/workflows/velocity-publish.yml` | Comment referencing `drift-labs/infrastructure-v3` updated |
| `package.json` | `@drift-labs/sdk` dependency key renamed to `@velocity-exchange/sdk` |
| `src/index.ts` | Two `@drift-labs/sdk` imports updated |
| `src/utils/utils.ts` | `@drift-labs/sdk` import updated |
| `src/wsConnectionManager.ts` | `@drift-labs/sdk` import updated |
| `example/client.ts` | `@drift-labs/sdk` import updated |
| `bun.lock` | All `@drift-labs/sdk` and `@drift-labs/common` package key references updated |
| `yarn.lock` | All `@drift-labs/sdk` package key references updated |

## Skipped (upstream-Drift historical refs)

- `README.md:15`: `github.com/drift-labs/protocol-v2/blob/...sdk/src/events/types.ts` - external link to the upstream Drift Protocol v2 repo used to document where valid `event_type`s are defined; this is a reference to the original upstream Drift project as a distinct entity, not this repo's own resource.

## Warning: @velocity-exchange npm scope

`@drift-labs/sdk` and `@drift-labs/common` are referenced as local `file:` deps (submodule paths), so the npm scope rename in source and lock files will not break the local build. However, if any consumer installs these packages from the npm registry, the packages must be republished under `@velocity-exchange/sdk` and `@velocity-exchange/common` before this change is deployed — the old `@drift-labs/*` registry entries won't resolve under the new scope.